### PR TITLE
Set eyeD3 version to one compatible with Python 2.7

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -40,7 +40,7 @@ RUN dpkg -i hugo.deb
 RUN rm hugo.deb
 
 RUN yes | apt install python-pip
-RUN pip install eyeD3 pathlib
+RUN pip install eyeD3==0.8.12 pathlib
 RUN mkdir /tools
 ADD tag.sh /tools/tag.sh
 RUN chmod +x /tools/tag.sh


### PR DESCRIPTION
We've noticed that the eyeD3 version installed after running recently the build step on our container was the 0.9.x, which [is not compatible with Python 2.7](https://github.com/nicfit/eyeD3/issues/381#issuecomment-571381196).

In order to avoid unexpected behaviors in the future, we're setting the expected eyeD3 version to one that is going to work well with the Python version currently available.